### PR TITLE
Run CI on PRs created by Scala Steward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: CI/CD
 
 on:
+  pull_request:
+    types:
+      - synchronize
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
   push:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - ready_for_review
       - reopened
       - unlocked
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,12 @@ name: CI/CD
 on:
   pull_request:
     types:
+      - opened
       - synchronize
       - edited
       - ready_for_review
       - reopened
       - unlocked
-  push:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Currently the CI flow is not run on Steward's PRs (example [here](https://github.com/softwaremill-academy/trading-template/pull/38)).
Following update intends to enhance action triggers in order to fix this issue.